### PR TITLE
[RFC/WIP] Class based embed finders

### DIFF
--- a/wagtail/wagtailcore/tests/test_rich_text.py
+++ b/wagtail/wagtailcore/tests/test_rich_text.py
@@ -97,7 +97,7 @@ class TestExpandDbHtml(TestCase):
         result = expand_db_html(html)
         self.assertEqual(result, '<a id="1">foo</a>')
 
-    @patch('wagtail.wagtailembeds.embeds.oembed')
+    @patch('wagtail.wagtailembeds.finders.oembed.find_embed')
     def test_expand_db_html_with_embed(self, oembed):
         oembed.return_value = {
             'title': 'test title',

--- a/wagtail/wagtailembeds/embeds.py
+++ b/wagtail/wagtailembeds/embeds.py
@@ -1,115 +1,12 @@
 from datetime import datetime
-import json
 
-# Needs to be imported like this to allow @patch to work in tests
-from django.utils.six.moves.urllib import request as urllib_request
-from django.utils.six.moves.urllib.request import Request
-from django.utils.six.moves.urllib.error import URLError
-from django.utils.six.moves.urllib.parse import urlencode
 from django.utils.module_loading import import_string
 from django.conf import settings
 
-from wagtail.wagtailembeds.oembed_providers import get_oembed_provider
 from wagtail.wagtailembeds.models import Embed
-
-
-class EmbedException(Exception):
-    pass
-
-
-class EmbedNotFoundException(EmbedException):
-    pass
-
-
-class EmbedlyException(EmbedException):
-    pass
-
-
-class AccessDeniedEmbedlyException(EmbedlyException):
-    pass
-
-
-def embedly(url, max_width=None, key=None):
-    from embedly import Embedly
-
-    # Get embedly key
-    if key is None:
-        key = settings.WAGTAILEMBEDS_EMBEDLY_KEY
-
-    # Get embedly client
-    client = Embedly(key=key)
-
-    # Call embedly
-    if max_width is not None:
-        oembed = client.oembed(url, maxwidth=max_width, better=False)
-    else:
-        oembed = client.oembed(url, better=False)
-
-    # Check for error
-    if oembed.get('error'):
-        if oembed['error_code'] in [401, 403]:
-            raise AccessDeniedEmbedlyException
-        elif oembed['error_code'] == 404:
-            raise EmbedNotFoundException
-        else:
-            raise EmbedlyException
-
-    # Convert photos into HTML
-    if oembed['type'] == 'photo':
-        html = '<img src="%s" />' % (oembed['url'], )
-    else:
-        html = oembed.get('html')
-
-    # Return embed as a dict
-    return {
-        'title': oembed['title'] if 'title' in oembed else '',
-        'author_name': oembed['author_name'] if 'author_name' in oembed else '',
-        'provider_name': oembed['provider_name'] if 'provider_name' in oembed else '',
-        'type': oembed['type'],
-        'thumbnail_url': oembed.get('thumbnail_url'),
-        'width': oembed.get('width'),
-        'height': oembed.get('height'),
-        'html': html,
-    }
-
-
-def oembed(url, max_width=None):
-    # Find provider
-    provider = get_oembed_provider(url)
-    if provider is None:
-        raise EmbedNotFoundException
-
-    # Work out params
-    params = {'url': url, 'format': 'json'}
-    if max_width:
-        params['maxwidth'] = max_width
-
-    # Perform request
-    request = Request(provider + '?' + urlencode(params))
-    request.add_header('User-agent', 'Mozilla/5.0')
-    try:
-        r = urllib_request.urlopen(request)
-    except URLError:
-        raise EmbedNotFoundException
-    oembed = json.loads(r.read().decode('utf-8'))
-
-    # Convert photos into HTML
-    if oembed['type'] == 'photo':
-        html = '<img src="%s" />' % (oembed['url'], )
-    else:
-        html = oembed.get('html')
-
-    # Return embed as a dict
-    return {
-        'title': oembed['title'] if 'title' in oembed else '',
-        'author_name': oembed['author_name'] if 'author_name' in oembed else '',
-        'provider_name': oembed['provider_name'] if 'provider_name' in oembed else '',
-        'type': oembed['type'],
-        'thumbnail_url': oembed.get('thumbnail_url'),
-        'width': oembed.get('width'),
-        'height': oembed.get('height'),
-        'html': html,
-    }
+from wagtail.wagtailembeds.exceptions import EmbedException, EmbedNotFoundException  # noqa
+from wagtail.wagtailembeds.finders.oembed import oembed
+from wagtail.wagtailembeds.finders.embedly import embedly
 
 
 def get_default_finder():
@@ -118,7 +15,7 @@ def get_default_finder():
         return import_string(settings.WAGTAILEMBEDS_EMBED_FINDER)
 
     # Use embedly if the embedly key is set
-    if hasattr(settings, 'WAGTAILEMBEDS_EMBEDLY_KEY') or hasattr(settings, 'EMBEDLY_KEY'):
+    if hasattr(settings, 'WAGTAILEMBEDS_EMBEDLY_KEY'):
         return embedly
 
     # Fall back to oembed

--- a/wagtail/wagtailembeds/embeds.py
+++ b/wagtail/wagtailembeds/embeds.py
@@ -1,25 +1,7 @@
 from datetime import datetime
 
-from django.utils.module_loading import import_string
-from django.conf import settings
-
 from wagtail.wagtailembeds.models import Embed
-from wagtail.wagtailembeds.exceptions import EmbedException, EmbedNotFoundException  # noqa
-from wagtail.wagtailembeds.finders.oembed import oembed
-from wagtail.wagtailembeds.finders.embedly import embedly
-
-
-def get_default_finder():
-    # Check if the user has set the embed finder manually
-    if hasattr(settings, 'WAGTAILEMBEDS_EMBED_FINDER'):
-        return import_string(settings.WAGTAILEMBEDS_EMBED_FINDER)
-
-    # Use embedly if the embedly key is set
-    if hasattr(settings, 'WAGTAILEMBEDS_EMBEDLY_KEY'):
-        return embedly
-
-    # Fall back to oembed
-    return oembed
+from wagtail.wagtailembeds.finders import get_default_finder
 
 
 def get_embed(url, max_width=None, finder=None):

--- a/wagtail/wagtailembeds/embeds.py
+++ b/wagtail/wagtailembeds/embeds.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 from wagtail.wagtailembeds.models import Embed
-from wagtail.wagtailembeds.finders import get_default_finder
+from wagtail.wagtailembeds.finders import get_finders
 
 
 def get_embed(url, max_width=None, finder=None):
@@ -13,7 +13,11 @@ def get_embed(url, max_width=None, finder=None):
 
     # Get/Call finder
     if not finder:
-        finder = get_default_finder()
+        def finder(url, max_width=None):
+            for finder in get_finders():
+                if finder.accept(url):
+                    return finder.find_embed(url, max_width=max_width)
+
     embed_dict = finder(url, max_width)
 
     # Make sure width and height are valid integers before inserting into database

--- a/wagtail/wagtailembeds/exceptions.py
+++ b/wagtail/wagtailembeds/exceptions.py
@@ -1,0 +1,6 @@
+class EmbedException(Exception):
+    pass
+
+
+class EmbedNotFoundException(EmbedException):
+    pass

--- a/wagtail/wagtailembeds/finders/__init__.py
+++ b/wagtail/wagtailembeds/finders/__init__.py
@@ -9,20 +9,22 @@ from django.conf import settings
 MOVED_FINDERS = {
     'wagtail.wagtailembeds.embeds.embedly': 'wagtail.wagtailembeds.finders.embedly',
     'wagtail.wagtailembeds.embeds.oembed': 'wagtail.wagtailembeds.finders.oembed',
+    'wagtail.wagtailembeds.finders.embedly.embedly': 'wagtail.wagtailembeds.finders.embedly',
+    'wagtail.wagtailembeds.finders.oembed.oembed': 'wagtail.wagtailembeds.finders.oembed',
 }
 
 
-def import_finder(dotted_path):
+def import_finder_class(dotted_path):
     """
-    Imports a finder function from a dotted path. If the dotted path points to a
-    module, that module is imported and its "find_embed" function returned.
+    Imports a finder class from a dotted path. If the dotted path points to a
+    module, that module is imported and its "embed_finder_class" class returned.
 
-    If not, this will assume the dotted path points to directly a function and
+    If not, this will assume the dotted path points to directly a class and
     will attempt to import that instead.
     """
     try:
         finder_module = import_module(dotted_path)
-        return finder_module.find_embed
+        return finder_module.embed_finder_class
     except ImportError as e:
         try:
             return import_string(dotted_path)
@@ -30,20 +32,46 @@ def import_finder(dotted_path):
             six.reraise(ImportError, e, sys.exc_info()[2])
 
 
-def get_default_finder():
-    # Check if the user has set the embed finder manually
-    if hasattr(settings, 'WAGTAILEMBEDS_EMBED_FINDER'):
+def _get_config_from_settings():
+    if hasattr(settings, 'WAGTAILEMBEDS_EMBED_FINDERS'):
+        return settings.WAGTAILEMBEDS_EMBED_FINDERS
+
+    elif hasattr(settings, 'WAGTAILEMBEDS_EMBED_FINDER'):
         finder_name = settings.WAGTAILEMBEDS_EMBED_FINDER
 
         if finder_name in MOVED_FINDERS:
             finder_name = MOVED_FINDERS[finder_name]
 
+        return [
+            {
+                'class': finder_name,
+            }
+        ]
+
     elif hasattr(settings, 'WAGTAILEMBEDS_EMBEDLY_KEY'):
-        # Default to Embedly as an embedly key is set
-        finder_name = 'wagtail.wagtailembeds.finders.embedly'
+        return [
+            {
+                'class': 'wagtail.wagtailembeds.finders.embedly',
+                'key': settings.WAGTAILEMBEDS_EMBEDLY_KEY,
+            }
+        ]
 
     else:
-        # Default to oembed
-        finder_name = 'wagtail.wagtailembeds.finders.oembed'
+        # Default to the oembed backend
+        return [
+            {
+                'class': 'wagtail.wagtailembeds.finders.oembed',
+            }
+        ]
 
-    return import_finder(finder_name)
+
+def get_finders():
+    finders = []
+
+    for finder_config in _get_config_from_settings():
+        finder_config = finder_config.copy()
+        cls = import_finder_class(finder_config.pop('class'))
+
+        finders.append(cls(**finder_config))
+
+    return finders

--- a/wagtail/wagtailembeds/finders/__init__.py
+++ b/wagtail/wagtailembeds/finders/__init__.py
@@ -5,10 +5,21 @@ from wagtail.wagtailembeds.finders.oembed import oembed
 from wagtail.wagtailembeds.finders.embedly import embedly
 
 
+MOVED_FINDERS = {
+    'wagtail.wagtailembeds.embeds.embedly': 'wagtail.wagtailembeds.finders.embedly.embedly',
+    'wagtail.wagtailembeds.embeds.oembed': 'wagtail.wagtailembeds.finders.oembed.oembed',
+}
+
+
 def get_default_finder():
     # Check if the user has set the embed finder manually
     if hasattr(settings, 'WAGTAILEMBEDS_EMBED_FINDER'):
-        return import_string(settings.WAGTAILEMBEDS_EMBED_FINDER)
+        finder_name = settings.WAGTAILEMBEDS_EMBED_FINDER
+
+        if finder_name in MOVED_FINDERS:
+            finder_name = MOVED_FINDERS[finder_name]
+
+        return import_string(finder_name)
 
     # Use embedly if the embedly key is set
     if hasattr(settings, 'WAGTAILEMBEDS_EMBEDLY_KEY'):

--- a/wagtail/wagtailembeds/finders/__init__.py
+++ b/wagtail/wagtailembeds/finders/__init__.py
@@ -1,9 +1,6 @@
 from django.utils.module_loading import import_string
 from django.conf import settings
 
-from wagtail.wagtailembeds.finders.oembed import oembed
-from wagtail.wagtailembeds.finders.embedly import embedly
-
 
 MOVED_FINDERS = {
     'wagtail.wagtailembeds.embeds.embedly': 'wagtail.wagtailembeds.finders.embedly.embedly',
@@ -19,11 +16,12 @@ def get_default_finder():
         if finder_name in MOVED_FINDERS:
             finder_name = MOVED_FINDERS[finder_name]
 
-        return import_string(finder_name)
+    elif hasattr(settings, 'WAGTAILEMBEDS_EMBEDLY_KEY'):
+        # Default to Embedly as an embedly key is set
+        finder_name = 'wagtail.wagtailembeds.finders.embedly.embedly'
 
-    # Use embedly if the embedly key is set
-    if hasattr(settings, 'WAGTAILEMBEDS_EMBEDLY_KEY'):
-        return embedly
+    else:
+        # Default to oembed
+        finder_name = 'wagtail.wagtailembeds.finders.oembed.oembed'
 
-    # Fall back to oembed
-    return oembed
+    return import_string(finder_name)

--- a/wagtail/wagtailembeds/finders/__init__.py
+++ b/wagtail/wagtailembeds/finders/__init__.py
@@ -1,0 +1,18 @@
+from django.utils.module_loading import import_string
+from django.conf import settings
+
+from wagtail.wagtailembeds.finders.oembed import oembed
+from wagtail.wagtailembeds.finders.embedly import embedly
+
+
+def get_default_finder():
+    # Check if the user has set the embed finder manually
+    if hasattr(settings, 'WAGTAILEMBEDS_EMBED_FINDER'):
+        return import_string(settings.WAGTAILEMBEDS_EMBED_FINDER)
+
+    # Use embedly if the embedly key is set
+    if hasattr(settings, 'WAGTAILEMBEDS_EMBEDLY_KEY'):
+        return embedly
+
+    # Fall back to oembed
+    return oembed

--- a/wagtail/wagtailembeds/finders/__init__.py
+++ b/wagtail/wagtailembeds/finders/__init__.py
@@ -1,11 +1,33 @@
+import sys
+from importlib import import_module
+
 from django.utils.module_loading import import_string
+from django.utils import six
 from django.conf import settings
 
 
 MOVED_FINDERS = {
-    'wagtail.wagtailembeds.embeds.embedly': 'wagtail.wagtailembeds.finders.embedly.embedly',
-    'wagtail.wagtailembeds.embeds.oembed': 'wagtail.wagtailembeds.finders.oembed.oembed',
+    'wagtail.wagtailembeds.embeds.embedly': 'wagtail.wagtailembeds.finders.embedly',
+    'wagtail.wagtailembeds.embeds.oembed': 'wagtail.wagtailembeds.finders.oembed',
 }
+
+
+def import_finder(dotted_path):
+    """
+    Imports a finder function from a dotted path. If the dotted path points to a
+    module, that module is imported and its "find_embed" function returned.
+
+    If not, this will assume the dotted path points to directly a function and
+    will attempt to import that instead.
+    """
+    try:
+        finder_module = import_module(dotted_path)
+        return finder_module.find_embed
+    except ImportError as e:
+        try:
+            return import_string(dotted_path)
+        except ImportError:
+            six.reraise(ImportError, e, sys.exc_info()[2])
 
 
 def get_default_finder():
@@ -18,10 +40,10 @@ def get_default_finder():
 
     elif hasattr(settings, 'WAGTAILEMBEDS_EMBEDLY_KEY'):
         # Default to Embedly as an embedly key is set
-        finder_name = 'wagtail.wagtailembeds.finders.embedly.embedly'
+        finder_name = 'wagtail.wagtailembeds.finders.embedly'
 
     else:
         # Default to oembed
-        finder_name = 'wagtail.wagtailembeds.finders.oembed.oembed'
+        finder_name = 'wagtail.wagtailembeds.finders.oembed'
 
-    return import_string(finder_name)
+    return import_finder(finder_name)

--- a/wagtail/wagtailembeds/finders/base.py
+++ b/wagtail/wagtailembeds/finders/base.py
@@ -1,0 +1,6 @@
+class EmbedFinder(object):
+    def accept(self, url):
+        return False
+
+    def find_embed(self, url, max_width=None):
+        raise NotImplementedError

--- a/wagtail/wagtailembeds/finders/embedly.py
+++ b/wagtail/wagtailembeds/finders/embedly.py
@@ -4,6 +4,8 @@ from django.conf import settings
 
 from wagtail.wagtailembeds.exceptions import EmbedException, EmbedNotFoundException
 
+from .base import EmbedFinder
+
 
 class EmbedlyException(EmbedException):
     pass
@@ -13,48 +15,53 @@ class AccessDeniedEmbedlyException(EmbedlyException):
     pass
 
 
-def embedly(url, max_width=None, key=None):
-    from embedly import Embedly
+class EmbedlyFinder(EmbedFinder):
+    def accept(self, url):
+        # We don't really know what embedly supports so accept everything
+        return True
 
-    # Get embedly key
-    if key is None:
-        key = settings.WAGTAILEMBEDS_EMBEDLY_KEY
+    def find_embed(self, url, max_width=None, key=None):
+        from embedly import Embedly
 
-    # Get embedly client
-    client = Embedly(key=key)
+        # Get embedly key
+        if key is None:
+            key = settings.WAGTAILEMBEDS_EMBEDLY_KEY
 
-    # Call embedly
-    if max_width is not None:
-        oembed = client.oembed(url, maxwidth=max_width, better=False)
-    else:
-        oembed = client.oembed(url, better=False)
+        # Get embedly client
+        client = Embedly(key=key)
 
-    # Check for error
-    if oembed.get('error'):
-        if oembed['error_code'] in [401, 403]:
-            raise AccessDeniedEmbedlyException
-        elif oembed['error_code'] == 404:
-            raise EmbedNotFoundException
+        # Call embedly
+        if max_width is not None:
+            oembed = client.oembed(url, maxwidth=max_width, better=False)
         else:
-            raise EmbedlyException
+            oembed = client.oembed(url, better=False)
 
-    # Convert photos into HTML
-    if oembed['type'] == 'photo':
-        html = '<img src="%s" />' % (oembed['url'], )
-    else:
-        html = oembed.get('html')
+        # Check for error
+        if oembed.get('error'):
+            if oembed['error_code'] in [401, 403]:
+                raise AccessDeniedEmbedlyException
+            elif oembed['error_code'] == 404:
+                raise EmbedNotFoundException
+            else:
+                raise EmbedlyException
 
-    # Return embed as a dict
-    return {
-        'title': oembed['title'] if 'title' in oembed else '',
-        'author_name': oembed['author_name'] if 'author_name' in oembed else '',
-        'provider_name': oembed['provider_name'] if 'provider_name' in oembed else '',
-        'type': oembed['type'],
-        'thumbnail_url': oembed.get('thumbnail_url'),
-        'width': oembed.get('width'),
-        'height': oembed.get('height'),
-        'html': html,
-    }
+        # Convert photos into HTML
+        if oembed['type'] == 'photo':
+            html = '<img src="%s" />' % (oembed['url'], )
+        else:
+            html = oembed.get('html')
+
+        # Return embed as a dict
+        return {
+            'title': oembed['title'] if 'title' in oembed else '',
+            'author_name': oembed['author_name'] if 'author_name' in oembed else '',
+            'provider_name': oembed['provider_name'] if 'provider_name' in oembed else '',
+            'type': oembed['type'],
+            'thumbnail_url': oembed.get('thumbnail_url'),
+            'width': oembed.get('width'),
+            'height': oembed.get('height'),
+            'html': html,
+        }
 
 
-find_embed = embedly
+embed_finder_class = EmbedlyFinder

--- a/wagtail/wagtailembeds/finders/embedly.py
+++ b/wagtail/wagtailembeds/finders/embedly.py
@@ -16,6 +16,18 @@ class AccessDeniedEmbedlyException(EmbedlyException):
 
 
 class EmbedlyFinder(EmbedFinder):
+    key = None
+
+    def __init__(self, key=None):
+        if key:
+            self.key = key
+
+    def get_key(self):
+        if self.key:
+            return self.key
+
+        return getattr(settings, 'WAGTAILEMBEDS_EMBEDLY_KEY', None)
+
     def accept(self, url):
         # We don't really know what embedly supports so accept everything
         return True
@@ -25,7 +37,7 @@ class EmbedlyFinder(EmbedFinder):
 
         # Get embedly key
         if key is None:
-            key = settings.WAGTAILEMBEDS_EMBEDLY_KEY
+            key = self.get_key()
 
         # Get embedly client
         client = Embedly(key=key)

--- a/wagtail/wagtailembeds/finders/embedly.py
+++ b/wagtail/wagtailembeds/finders/embedly.py
@@ -1,0 +1,57 @@
+from __future__ import absolute_import
+
+from django.conf import settings
+
+from wagtail.wagtailembeds.exceptions import EmbedException, EmbedNotFoundException
+
+
+class EmbedlyException(EmbedException):
+    pass
+
+
+class AccessDeniedEmbedlyException(EmbedlyException):
+    pass
+
+
+def embedly(url, max_width=None, key=None):
+    from embedly import Embedly
+
+    # Get embedly key
+    if key is None:
+        key = settings.WAGTAILEMBEDS_EMBEDLY_KEY
+
+    # Get embedly client
+    client = Embedly(key=key)
+
+    # Call embedly
+    if max_width is not None:
+        oembed = client.oembed(url, maxwidth=max_width, better=False)
+    else:
+        oembed = client.oembed(url, better=False)
+
+    # Check for error
+    if oembed.get('error'):
+        if oembed['error_code'] in [401, 403]:
+            raise AccessDeniedEmbedlyException
+        elif oembed['error_code'] == 404:
+            raise EmbedNotFoundException
+        else:
+            raise EmbedlyException
+
+    # Convert photos into HTML
+    if oembed['type'] == 'photo':
+        html = '<img src="%s" />' % (oembed['url'], )
+    else:
+        html = oembed.get('html')
+
+    # Return embed as a dict
+    return {
+        'title': oembed['title'] if 'title' in oembed else '',
+        'author_name': oembed['author_name'] if 'author_name' in oembed else '',
+        'provider_name': oembed['provider_name'] if 'provider_name' in oembed else '',
+        'type': oembed['type'],
+        'thumbnail_url': oembed.get('thumbnail_url'),
+        'width': oembed.get('width'),
+        'height': oembed.get('height'),
+        'html': html,
+    }

--- a/wagtail/wagtailembeds/finders/embedly.py
+++ b/wagtail/wagtailembeds/finders/embedly.py
@@ -55,3 +55,6 @@ def embedly(url, max_width=None, key=None):
         'height': oembed.get('height'),
         'html': html,
     }
+
+
+find_embed = embedly

--- a/wagtail/wagtailembeds/finders/oembed.py
+++ b/wagtail/wagtailembeds/finders/oembed.py
@@ -1,0 +1,51 @@
+from __future__ import absolute_import
+
+import json
+
+# Needs to be imported like this to allow @patch to work in tests
+from django.utils.six.moves.urllib import request as urllib_request
+from django.utils.six.moves.urllib.request import Request
+from django.utils.six.moves.urllib.error import URLError
+from django.utils.six.moves.urllib.parse import urlencode
+
+from wagtail.wagtailembeds.oembed_providers import get_oembed_provider
+from wagtail.wagtailembeds.exceptions import EmbedNotFoundException
+
+
+def oembed(url, max_width=None):
+    # Find provider
+    provider = get_oembed_provider(url)
+    if provider is None:
+        raise EmbedNotFoundException
+
+    # Work out params
+    params = {'url': url, 'format': 'json'}
+    if max_width:
+        params['maxwidth'] = max_width
+
+    # Perform request
+    request = Request(provider + '?' + urlencode(params))
+    request.add_header('User-agent', 'Mozilla/5.0')
+    try:
+        r = urllib_request.urlopen(request)
+    except URLError:
+        raise EmbedNotFoundException
+    oembed = json.loads(r.read().decode('utf-8'))
+
+    # Convert photos into HTML
+    if oembed['type'] == 'photo':
+        html = '<img src="%s" />' % (oembed['url'], )
+    else:
+        html = oembed.get('html')
+
+    # Return embed as a dict
+    return {
+        'title': oembed['title'] if 'title' in oembed else '',
+        'author_name': oembed['author_name'] if 'author_name' in oembed else '',
+        'provider_name': oembed['provider_name'] if 'provider_name' in oembed else '',
+        'type': oembed['type'],
+        'thumbnail_url': oembed.get('thumbnail_url'),
+        'width': oembed.get('width'),
+        'height': oembed.get('height'),
+        'html': html,
+    }

--- a/wagtail/wagtailembeds/finders/oembed.py
+++ b/wagtail/wagtailembeds/finders/oembed.py
@@ -49,3 +49,6 @@ def oembed(url, max_width=None):
         'height': oembed.get('height'),
         'html': html,
     }
+
+
+find_embed = oembed

--- a/wagtail/wagtailembeds/finders/oembed.py
+++ b/wagtail/wagtailembeds/finders/oembed.py
@@ -11,44 +11,50 @@ from django.utils.six.moves.urllib.parse import urlencode
 from wagtail.wagtailembeds.oembed_providers import get_oembed_provider
 from wagtail.wagtailembeds.exceptions import EmbedNotFoundException
 
-
-def oembed(url, max_width=None):
-    # Find provider
-    provider = get_oembed_provider(url)
-    if provider is None:
-        raise EmbedNotFoundException
-
-    # Work out params
-    params = {'url': url, 'format': 'json'}
-    if max_width:
-        params['maxwidth'] = max_width
-
-    # Perform request
-    request = Request(provider + '?' + urlencode(params))
-    request.add_header('User-agent', 'Mozilla/5.0')
-    try:
-        r = urllib_request.urlopen(request)
-    except URLError:
-        raise EmbedNotFoundException
-    oembed = json.loads(r.read().decode('utf-8'))
-
-    # Convert photos into HTML
-    if oembed['type'] == 'photo':
-        html = '<img src="%s" />' % (oembed['url'], )
-    else:
-        html = oembed.get('html')
-
-    # Return embed as a dict
-    return {
-        'title': oembed['title'] if 'title' in oembed else '',
-        'author_name': oembed['author_name'] if 'author_name' in oembed else '',
-        'provider_name': oembed['provider_name'] if 'provider_name' in oembed else '',
-        'type': oembed['type'],
-        'thumbnail_url': oembed.get('thumbnail_url'),
-        'width': oembed.get('width'),
-        'height': oembed.get('height'),
-        'html': html,
-    }
+from .base import EmbedFinder
 
 
-find_embed = oembed
+class OEmbedFinder(EmbedFinder):
+    def accept(self, url):
+        return get_oembed_provider(url) is not None
+
+    def find_embed(self, url, max_width=None):
+        # Find provider
+        provider = get_oembed_provider(url)
+        if provider is None:
+            raise EmbedNotFoundException
+
+        # Work out params
+        params = {'url': url, 'format': 'json'}
+        if max_width:
+            params['maxwidth'] = max_width
+
+        # Perform request
+        request = Request(provider + '?' + urlencode(params))
+        request.add_header('User-agent', 'Mozilla/5.0')
+        try:
+            r = urllib_request.urlopen(request)
+        except URLError:
+            raise EmbedNotFoundException
+        oembed = json.loads(r.read().decode('utf-8'))
+
+        # Convert photos into HTML
+        if oembed['type'] == 'photo':
+            html = '<img src="%s" />' % (oembed['url'], )
+        else:
+            html = oembed.get('html')
+
+        # Return embed as a dict
+        return {
+            'title': oembed['title'] if 'title' in oembed else '',
+            'author_name': oembed['author_name'] if 'author_name' in oembed else '',
+            'provider_name': oembed['provider_name'] if 'provider_name' in oembed else '',
+            'type': oembed['type'],
+            'thumbnail_url': oembed.get('thumbnail_url'),
+            'width': oembed.get('width'),
+            'height': oembed.get('height'),
+            'html': html,
+        }
+
+
+embed_finder_class = OEmbedFinder

--- a/wagtail/wagtailembeds/finders/oembed.py
+++ b/wagtail/wagtailembeds/finders/oembed.py
@@ -15,6 +15,13 @@ from .base import EmbedFinder
 
 
 class OEmbedFinder(EmbedFinder):
+    options = {}
+
+    def __init__(self, options=None):
+        if options:
+            self.options = self.options.copy()
+            self.options.update(options)
+
     def accept(self, url):
         return get_oembed_provider(url) is not None
 
@@ -25,7 +32,9 @@ class OEmbedFinder(EmbedFinder):
             raise EmbedNotFoundException
 
         # Work out params
-        params = {'url': url, 'format': 'json'}
+        params = self.options.copy()
+        params['url'] = url
+        params['format'] = 'json'
         if max_width:
             params['maxwidth'] = max_width
 

--- a/wagtail/wagtailembeds/finders/oembed.py
+++ b/wagtail/wagtailembeds/finders/oembed.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import json
+import re
 
 # Needs to be imported like this to allow @patch to work in tests
 from django.utils.six.moves.urllib import request as urllib_request
@@ -8,7 +9,7 @@ from django.utils.six.moves.urllib.request import Request
 from django.utils.six.moves.urllib.error import URLError
 from django.utils.six.moves.urllib.parse import urlencode
 
-from wagtail.wagtailembeds.oembed_providers import get_oembed_provider
+from wagtail.wagtailembeds.oembed_providers import all_providers
 from wagtail.wagtailembeds.exceptions import EmbedNotFoundException
 
 from .base import EmbedFinder
@@ -16,19 +17,37 @@ from .base import EmbedFinder
 
 class OEmbedFinder(EmbedFinder):
     options = {}
+    _endpoints = None
 
-    def __init__(self, options=None):
+    def __init__(self, providers=None, options=None):
+        self._endpoints = {}
+
+        for provider in providers or all_providers:
+            patterns = []
+
+            for url in provider['urls']:
+                url = url.replace('{format}', 'json')
+                patterns.append(re.compile(url))
+
+            self._endpoints[provider['endpoint']] = patterns
+
         if options:
             self.options = self.options.copy()
             self.options.update(options)
 
+    def _get_endpoint(self, url):
+        for endpoint, patterns in self._endpoints.items():
+            for pattern in patterns:
+                if re.match(pattern, url):
+                    return endpoint
+
     def accept(self, url):
-        return get_oembed_provider(url) is not None
+        return self._get_endpoint(url) is not None
 
     def find_embed(self, url, max_width=None):
         # Find provider
-        provider = get_oembed_provider(url)
-        if provider is None:
+        endpoint = self._get_endpoint(url)
+        if endpoint is None:
             raise EmbedNotFoundException
 
         # Work out params
@@ -39,7 +58,7 @@ class OEmbedFinder(EmbedFinder):
             params['maxwidth'] = max_width
 
         # Perform request
-        request = Request(provider + '?' + urlencode(params))
+        request = Request(endpoint + '?' + urlencode(params))
         request.add_header('User-agent', 'Mozilla/5.0')
         try:
             r = urllib_request.urlopen(request)

--- a/wagtail/wagtailembeds/format.py
+++ b/wagtail/wagtailembeds/format.py
@@ -3,6 +3,7 @@ from __future__ import division  # Use true division
 from django.template.loader import render_to_string
 
 from wagtail.wagtailembeds import embeds
+from wagtail.wagtailembeds.exceptions import EmbedException
 
 
 def embed_to_frontend_html(url):
@@ -20,7 +21,7 @@ def embed_to_frontend_html(url):
             'embed': embed,
             'ratio': ratio,
         })
-    except embeds.EmbedException:
+    except EmbedException:
         # silently ignore failed embeds, rather than letting them crash the page
         return ''
 

--- a/wagtail/wagtailembeds/oembed_providers.py
+++ b/wagtail/wagtailembeds/oembed_providers.py
@@ -1,12 +1,21 @@
-OEMBED_ENDPOINTS = {
-    "https://speakerdeck.com/oembed.{format}": [
+speakerdeck = {
+    "endpoint": "https://speakerdeck.com/oembed.{format}",
+    "urls": [
         "^http(?:s)?://speakerdeck\\.com/.+$"
     ],
-    "https://alpha-api.app.net/oembed": [
+}
+
+app_net = {
+    "endpoint": "https://alpha-api.app.net/oembed",
+    "urls": [
         "^http(?:s)?://alpha\\.app\\.net/[^#?/]+/post/.+$",
         "^http(?:s)?://photos\\.app\\.net/[^#?/]+/.+$"
     ],
-    "http://www.youtube.com/oembed": [
+}
+
+youtube = {
+    "endpoint": "http://www.youtube.com/oembed",
+    "urls": [
         "^http(?:s)?://(?:[-\\w]+\\.)?youtube\\.com/watch.+$",
         "^http(?:s)?://(?:[-\\w]+\\.)?youtube\\.com/v/.+$",
         "^http(?:s)?://youtu\\.be/.+$",
@@ -17,311 +26,601 @@ OEMBED_ENDPOINTS = {
         "^http(?:s)?://(?:[-\\w]+\\.)?youtube\\.com/view_play_list.+$",
         "^http(?:s)?://(?:[-\\w]+\\.)?youtube\\.com/playlist.+$"
     ],
-    "http://backend.deviantart.com/oembed": [
+}
+
+deviantart = {
+    "endpoint": "http://backend.deviantart.com/oembed",
+    "urls": [
         "^http://(?:[-\\w]+\\.)?deviantart\\.com/art/.+$",
         "^http://fav\\.me/.+$",
         "^http://sta\\.sh/.+$",
         "^http://(?:[-\\w]+\\.)?deviantart\\.com/[^#?/]+#/d.+$"
     ],
-    "http://blip.tv/oembed/": [
+}
+
+blip_tv = {
+    "endpoint": "http://blip.tv/oembed/",
+    "urls": [
         "^http://[-\\w]+\\.blip\\.tv/.+$"
     ],
-    "http://www.dailymotion.com/api/oembed/": [
+}
+
+dailymotion = {
+    "endpoint": "http://www.dailymotion.com/api/oembed/",
+    "urls": [
         "^http://[-\\w]+\\.dailymotion\\.com/.+$"
     ],
-    "http://www.flickr.com/services/oembed/": [
+}
+
+flikr = {
+    "endpoint": "http://www.flickr.com/services/oembed/",
+    "urls": [
         "^http://[-\\w]+\\.flickr\\.com/photos/.+$",
         "^http://flic\\.kr\\.com/.+$"
     ],
-    "http://www.hulu.com/api/oembed.{format}": [
+}
+
+hulu = {
+    "endpoint": "http://www.hulu.com/api/oembed.{format}",
+    "urls": [
         "^http://www\\.hulu\\.com/watch/.+$"
     ],
-    "http://www.nfb.ca/remote/services/oembed/": [
+}
+
+nfb = {
+    "endpoint": "http://www.nfb.ca/remote/services/oembed/",
+    "urls": [
         "^http://(?:[-\\w]+\\.)?nfb\\.ca/film/.+$"
     ],
-    "http://qik.com/api/oembed.{format}": [
+}
+
+qik = {
+    "endpoint": "http://qik.com/api/oembed.{format}",
+    "urls": [
         "^http://qik\\.com/.+$",
         "^http://qik\\.ly/.+$"
     ],
-    "http://revision3.com/api/oembed/": [
+}
+
+revision3 = {
+    "endpoint": "http://revision3.com/api/oembed/",
+    "urls": [
         "^http://[-\\w]+\\.revision3\\.com/.+$"
     ],
-    "http://www.scribd.com/services/oembed": [
+}
+
+scribd = {
+    "endpoint": "http://www.scribd.com/services/oembed",
+    "urls": [
         "^http://[-\\w]+\\.scribd\\.com/.+$"
     ],
-    "http://www.viddler.com/oembed/": [
+}
+
+viddler = {
+    "endpoint": "http://www.viddler.com/oembed/",
+    "urls": [
         "^http://[-\\w]+\\.viddler\\.com/v/.+$",
         "^http://[-\\w]+\\.viddler\\.com/explore/.+$"
     ],
-    "http://www.vimeo.com/api/oembed.{format}": [
+}
+
+vimeo = {
+    "endpoint": "http://www.vimeo.com/api/oembed.{format}",
+    "urls": [
         "^http(?:s)?://(?:www\\.)?vimeo\\.com/.+$",
         "^http(?:s)?://player\\.vimeo\\.com/.+$"
     ],
-    "http://dotsub.com/services/oembed": [
+}
+
+dotsub = {
+    "endpoint": "http://dotsub.com/services/oembed",
+    "urls": [
         "^http://dotsub\\.com/view/.+$"
     ],
-    "http://www.yfrog.com/api/oembed": [
+}
+
+yfrog = {
+    "endpoint": "http://www.yfrog.com/api/oembed",
+    "urls": [
         "^http(?:s)?://(?:www\\.)?yfrog\\.com/.+$",
         "^http(?:s)?://(?:www\\.)?yfrog\\.us/.+$"
     ],
-    "http://clikthrough.com/services/oembed": [
+}
+
+clickthrough = {
+    "endpoint": "http://clikthrough.com/services/oembed",
+    "urls": [
         "^http(?:s)?://(?:[-\\w]+\\.)?clikthrough\\.com/.+$"
     ],
-    "http://www.kinomap.com/oembed": [
+}
+
+kinomap = {
+    "endpoint": "http://www.kinomap.com/oembed",
+    "urls": [
         "^http://[-\\w]+\\.kinomap\\.com/.+$"
     ],
-    "https://photobucket.com/oembed": [
+}
+
+photobucket = {
+    "endpoint": "https://photobucket.com/oembed",
+    "urls": [
         "^http://(?:[-\\w]+\\.)?photobucket\\.com/albums/.+$",
         "^http://(?:[-\\w]+\\.)?photobucket\\.com/groups/.+$"
     ],
-    "http://api.instagram.com/oembed": [
+}
+
+instagram = {
+    "endpoint": "http://api.instagram.com/oembed",
+    "urls": [
         "^http://instagr\\.am/p/.+$",
         "^http[s]?://instagram\\.com/p/.+$"
     ],
-    "https://www.slideshare.net/api/oembed/2": [
+}
+
+slideshare = {
+    "endpoint": "https://www.slideshare.net/api/oembed/2",
+    "urls": [
         "^http://www\\.slideshare\\.net/.+$"
     ],
-    "http://tv.majorleaguegaming.com/oembed": [
+}
+
+major_league_gaming = {
+    "endpoint": "http://tv.majorleaguegaming.com/oembed",
+    "urls": [
         "^http://mlg\\.tv/.+$",
         "^http://tv\\.majorleaguegaming\\.com/.+$"
     ],
-    "http://my.opera.com/service/oembed": [
+}
+
+opera = {
+    "endpoint": "http://my.opera.com/service/oembed",
+    "urls": [
         "^http://my\\.opera\\.com/.+$"
     ],
-    "http://skitch.com/oembed": [
+}
+
+skitch = {
+    "endpoint": "http://skitch.com/oembed",
+    "urls": [
         "^http(?:s)?://(?:www\\.)?skitch\\.com/.+$",
         "^http://skit\\.ch/.+$"
     ],
-    "https://api.twitter.com/1/statuses/oembed.{format}": [
+}
+
+twitter = {
+    "endpoint": "https://api.twitter.com/1/statuses/oembed.{format}",
+    "urls": [
         "^http(?:s)?://twitter\\.com/(?:#!)?[^#?/]+/status/.+$"
     ],
-    "https://soundcloud.com/oembed": [
+}
+
+soundcloud = {
+    "endpoint": "https://soundcloud.com/oembed",
+    "urls": [
         "^https://soundcloud\\.com/[^#?/]+/.+$"
     ],
-    "http://www.collegehumor.com/oembed.{format}": [
+}
+
+collegehumor = {
+    "endpoint": "http://www.collegehumor.com/oembed.{format}",
+    "urls": [
         "^http://(?:www\\.)?collegehumor\\.com/video/.+$",
         "^http://(?:www\\.)?collegehumor\\.com/video:.+$"
     ],
-    "http://www.polleverywhere.com/services/oembed/": [
+}
+
+polleverywhere = {
+    "endpoint": "http://www.polleverywhere.com/services/oembed/",
+    "urls": [
         "^http://www\\.polleverywhere\\.com/polls/.+$",
         "^http://www\\.polleverywhere\\.com/multiple_choice_polls/.+$",
         "^http://www\\.polleverywhere\\.com/free_text_polls/.+$"
     ],
-    "http://www.ifixit.com/Embed": [
+}
+
+ifixit = {
+    "endpoint": "http://www.ifixit.com/Embed",
+    "urls": [
         "^http://www\\.ifixit\\.com/[^#?/]+/[^#?/]+/.+$"
     ],
-    "http://api.smugmug.com/services/oembed/": [
+}
+
+smugmug = {
+    "endpoint": "http://api.smugmug.com/services/oembed/",
+    "urls": [
         "^http(?:s)?://(?:www\\.)?smugmug\\.com/[^#?/]+/.+$"
     ],
-    "https://github.com/api/oembed": [
+}
+
+github_gist = {
+    "endpoint": "https://github.com/api/oembed",
+    "urls": [
         "^http(?:s)?://gist\\.github\\.com/.+$"
     ],
-    "http://animoto.com/services/oembed": [
+}
+
+animoto = {
+    "endpoint": "http://animoto.com/services/oembed",
+    "urls": [
         "^http://animoto\\.com/play/.+$"
     ],
-    "http://www.rdio.com/api/oembed": [
+}
+
+rdio = {
+    "endpoint": "http://www.rdio.com/api/oembed",
+    "urls": [
         "^http://(?:wwww\\.)?rdio\\.com/people/[^#?/]+/playlists/.+$",
         "^http://[-\\w]+\\.rdio\\.com/artist/[^#?/]+/album/.+$"
     ],
-    "http://api.5min.com/oembed.{format}": [
+}
+
+five_min = {
+    "endpoint": "http://api.5min.com/oembed.{format}",
+    "urls": [
         "^http://www\\.5min\\.com/video/.+$"
     ],
-    "http://500px.com/photo/{1}/oembed.{format}": [
+}
+
+five_hundred_px = {
+    "endpoint": "http://500px.com/photo/{1}/oembed.{format}",
+    "urls": [
         "^http://500px\\.com/photo/([^#?/]+)(?:.+)?$"
     ],
-    "http://api.dipdive.com/oembed.{format}": [
+}
+
+dipdive = {
+    "endpoint": "http://api.dipdive.com/oembed.{format}",
+    "urls": [
         "^http://[-\\w]+\\.dipdive\\.com/media/.+$"
     ],
-    "http://video.yandex.ru/oembed.{format}": [
+}
+
+yandex = {
+    "endpoint": "http://video.yandex.ru/oembed.{format}",
+    "urls": [
         "^http://video\\.yandex\\.ru/users/[^#?/]+/view/.+$"
     ],
-    "http://www.mixcloud.com/oembed/": [
+}
+
+mixcloud = {
+    "endpoint": "http://www.mixcloud.com/oembed/",
+    "urls": [
         "^http://www\\.mixcloud\\.com/oembed/[^#?/]+/.+$"
     ],
-    "http://www.kickstarter.com/services/oembed": [
+}
+
+kickstarter = {
+    "endpoint": "http://www.kickstarter.com/services/oembed",
+    "urls": [
         "^http(?:s)://[-\\w]+\\.kickstarter\\.com/projects/.+$"
     ],
-    "http://coub.com/api/oembed.{format}": [
+}
+
+coub = {
+    "endpoint": "http://coub.com/api/oembed.{format}",
+    "urls": [
         "^http(?:s)?://coub\\.com/view/.+$",
         "^http(?:s)?://coub\\.com/embed/.+$"
     ],
-    "http://www.screenr.com/api/oembed.{format}": [
+}
+
+screenr = {
+    "endpoint": "http://www.screenr.com/api/oembed.{format}",
+    "urls": [
         "^http://www\\.screenr\\.com/.+$"
     ],
-    "http://www.funnyordie.com/oembed.{format}": [
+}
+
+funny_or_die = {
+    "endpoint": "http://www.funnyordie.com/oembed.{format}",
+    "urls": [
         "^http://www\\.funnyordie\\.com/videos/.+$"
     ],
-    "http://fast.wistia.com/oembed.{format}": [
+}
+
+wistia = {
+    "endpoint": "http://fast.wistia.com/oembed.{format}",
+    "urls": [
         "^http://[-\\w]+\\.wista\\.com/medias/.+$"
     ],
-    "http://www.ustream.tv/oembed": [
+}
+
+ustream = {
+    "endpoint": "http://www.ustream.tv/oembed",
+    "urls": [
         "^http(?:s)?://(?:www\\.)?ustream\\.tv/.+$",
         "^http(?:s)?://(?:www\\.)?ustream\\.com/.+$",
         "^http://ustre\\.am/.+$"
     ],
-    "http://wordpress.tv/oembed/": [
+}
+
+wordpress = {
+    "endpoint": "http://wordpress.tv/oembed/",
+    "urls": [
         "^http://wordpress\\.tv/.+$"
     ],
-    "http://polldaddy.com/oembed/": [
+}
+
+polldaddy = {
+    "endpoint": "http://polldaddy.com/oembed/",
+    "urls": [
         "^http(?:s)?://(?:[-\\w]+\\.)?polldaddy\\.com/.+$"
     ],
-    "http://api.bambuser.com/oembed.{format}": [
+}
+
+bambuser = {
+    "endpoint": "http://api.bambuser.com/oembed.{format}",
+    "urls": [
         "^http://bambuser\\.com/channel/[^#?/]+/broadcast/.+$",
         "^http://bambuser\\.com/channel/.+$",
         "^http://bambuser\\.com/v/.+$"
     ],
-    "http://www.ted.com/talks/oembed.{format}": [
+}
+
+ted = {
+    "endpoint": "http://www.ted.com/talks/oembed.{format}",
+    "urls": [
         "^http(?:s)?://(?:www\\.)?ted\\.com/talks/.+$",
         "^http(?:s)?://(?:www\\.)?ted\\.com/talks/lang/[^#?/]+/.+$",
         "^http(?:s)?://(?:www\\.)?ted\\.com/index\\.php/talks/.+$",
         "^http(?:s)?://(?:www\\.)?ted\\.com/index\\.php/talks/lang/[^#?/]+/.+$"
     ],
-    "http://chirb.it/oembed.{format}": [
+}
+
+chirb = {
+    "endpoint": "http://chirb.it/oembed.{format}",
+    "urls": [
         "^http://chirb\\.it/.+$"
     ],
-    "https://www.circuitlab.com/circuit/oembed/": [
+}
+
+circuitlab = {
+    "endpoint": "https://www.circuitlab.com/circuit/oembed/",
+    "urls": [
         "^http(?:s)?://(?:www\\.)?circuitlab\\.com/circuit/.+$"
     ],
-    "http://api.geograph.org.uk/api/oembed": [
+}
+
+geograph_uk = {
+    "endpoint": "http://api.geograph.org.uk/api/oembed",
+    "urls": [
         "^http://(?:[-\\w]+\\.)?geograph\\.org\\.uk/.+$",
         "^http://(?:[-\\w]+\\.)?geograph\\.co\\.uk/.+$",
         "^http://(?:[-\\w]+\\.)?geograph\\.ie/.+$"
     ],
-    "http://geo.hlipp.de/restapi.php/api/oembed": [
+}
+
+hlipp = {
+    "endpoint": "http://geo.hlipp.de/restapi.php/api/oembed",
+    "urls": [
         "^http://geo-en\\.hlipp\\.de/.+$",
         "^http://geo\\.hlipp\\.de/.+$",
         "^http://germany\\.geograph\\.org/.+$"
     ],
-    "http://www.geograph.org.gg/api/oembed": [
+}
+
+geograph_gg = {
+    "endpoint": "http://www.geograph.org.gg/api/oembed",
+    "urls": [
         "^http://(?:[-\\w]+\\.)?geograph\\.org\\.gg/.+$",
         "^http://(?:[-\\w]+\\.)?geograph\\.org\\.je/.+$",
         "^http://channel-islands\\.geograph\\.org/.+$",
         "^http://channel-islands\\.geographs\\.org/.+$",
         "^http://(?:[-\\w]+\\.)?channel\\.geographs\\.org/.+$"
     ],
-    "http://vzaar.com/api/videos/{1}.{format}": [
+}
+
+vzaar = {
+    "endpoint": "http://vzaar.com/api/videos/{1}.{format}",
+    "urls": [
         "^http://(?:www\\.)?vzaar\\.com/videos/([^#?/]+)(?:.+)?$",
         "^http://www\\.vzaar\\.tv/([^#?/]+)(?:.+)?$",
         "^http://vzaar\\.tv/([^#?/]+)(?:.+)?$",
         "^http://vzaar\\.me/([^#?/]+)(?:.+)?$",
         "^http://[-\\w]+\\.vzaar\\.me/([^#?/]+)(?:.+)?$"
     ],
-    "http://api.minoto-video.com/services/oembed.{format}": [
+}
+
+minoto = {
+    "endpoint": "http://api.minoto-video.com/services/oembed.{format}",
+    "urls": [
         "^http://api\\.minoto-video\\.com/publishers/[^#?/]+/videos/.+$",
         "^http://dashboard\\.minoto-video\\.com/main/video/details/.+$",
         "^http://embed\\.minoto-video\\.com/.+$"
     ],
-    "http://www.videojug.com/oembed.{format}": [
+}
+
+videojug = {
+    "endpoint": "http://www.videojug.com/oembed.{format}",
+    "urls": [
         "^http(?:s)?://(?:[-\\w]+\\.)?videojug\\.com/film/.+$",
         "^http(?:s)?://(?:[-\\w]+\\.)?videojug\\.com/payer/.+$",
         "^http(?:s)?://(?:[-\\w]+\\.)?videojug\\.com/interview/.+$"
     ],
-    "http://videos.sapo.pt/oembed": [
+}
+
+sapo = {
+    "endpoint": "http://videos.sapo.pt/oembed",
+    "urls": [
         "^http(?:s)?://videos\\.sapo\\.pt/.+$"
     ],
-    "http://vhx.tv/services/oembed.{format}": [
+}
+
+vhx_tv = {
+    "endpoint": "http://vhx.tv/services/oembed.{format}",
+    "urls": [
         "^http(?:s)?://(?:www\\.)?vhx\\.tv/.+$"
     ],
-    "http://api.justin.tv/api/embed/from_url.{format}": [
+}
+
+justin_tv = {
+    "endpoint": "http://api.justin.tv/api/embed/from_url.{format}",
+    "urls": [
         "^http(?:s)?://(?:www\\.)?justin\\.tv/.+$"
     ],
-    "http://official.fm/services/oembed.{format}": [
+}
+
+official_fm = {
+    "endpoint": "http://official.fm/services/oembed.{format}",
+    "urls": [
         "^http(?:s)?://official\\.fm/.+$"
     ],
-    "http://huffduffer.com/oembed": [
+}
+
+huffduffer = {
+    "endpoint": "http://huffduffer.com/oembed",
+    "urls": [
         "^http(?:s)?://(?:www\\.)?huffduffer\\.com/[^#?/]+/.+$"
     ],
-    "https://embed.spotify.com/oembed/": [
+}
+
+spotify = {
+    "endpoint": "https://embed.spotify.com/oembed/",
+    "urls": [
         "^http(?:s)?://open\\.spotify\\.com/.+$",
         "^http(?:s)?://spoti\\.fi/.+$"
     ],
-    "http://shoudio.com/api/oembed": [
+}
+
+shoudio = {
+    "endpoint": "http://shoudio.com/api/oembed",
+    "urls": [
         "^http://shoudio\\.com/.+$",
         "^http://shoud\\.io/.+$"
     ],
-    "http://api.mobypicture.com/oEmbed": [
+}
+
+mobypicture = {
+    "endpoint": "http://api.mobypicture.com/oEmbed",
+    "urls": [
         "^http(?:s)?://(?:www\\.)?mobypicture\\.com/user/[^#?/]+/view/.+$",
         "^http(?:s)?://(?:www\\.)?moby\\.to/.+$"
     ],
-    "http://www.23hq.com/23/oembed": [
+}
+
+twenty_three_hq = {
+    "endpoint": "http://www.23hq.com/23/oembed",
+    "urls": [
         "^http(?:s)?://(?:www\\.)?23hq\\.com/[^#?/]+/photo/.+$"
     ],
-    "http://gmep.org/oembed.{format}": [
+}
+
+gmep = {
+    "endpoint": "http://gmep.org/oembed.{format}",
+    "urls": [
         "^http(?:s)?://(?:www\\.)?gmep\\.org/.+$",
         "^http(?:s)?://gmep\\.imeducate\\.com/.+$"
     ],
-    "http://oembed.urtak.com/1/oembed": [
+}
+
+urtak = {
+    "endpoint": "http://oembed.urtak.com/1/oembed",
+    "urls": [
         "^http(?:s)?://(?:[-\\w]+\\.)?urtak\\.com/.+$"
     ],
-    "http://cacoo.com/oembed.{format}": [
+}
+
+cacoo = {
+    "endpoint": "http://cacoo.com/oembed.{format}",
+    "urls": [
         "^http(?:s)?://cacoo\\.com/.+$"
     ],
-    "http://api.dailymile.com/oembed": [
+}
+
+dailymile = {
+    "endpoint": "http://api.dailymile.com/oembed",
+    "urls": [
         "^http(?:s)?://(?:www\\.)?dailymile\\.com/people/[^#?/]+/entries/.+$"
     ],
-    "http://www.dipity.com/oembed/timeline/": [
+}
+
+dipity = {
+    "endpoint": "http://www.dipity.com/oembed/timeline/",
+    "urls": [
         "^http(?:s)?://(?:www\\.)?dipity\\.com/timeline/.+$",
         "^http(?:s)?://(?:www\\.)?dipity\\.com/voaweb/.+$"
     ],
-    "https://sketchfab.com/oembed": [
+}
+
+sketchfab = {
+    "endpoint": "https://sketchfab.com/oembed",
+    "urls": [
         "^http(?:s)?://sketchfab\\.com/show/.+$"
     ],
-    "https://api.meetup.com/oembed": [
+}
+
+meetup = {
+    "endpoint": "https://api.meetup.com/oembed",
+    "urls": [
         "^http(?:s)?://(?:www\\.)?meetup\\.com/.+$",
         "^http(?:s)?://(?:www\\.)?meetup\\.ps/.+$"
     ],
-    "https://roomshare.jp/oembed.{format}": [
+}
+
+roomshare = {
+    "endpoint": "https://roomshare.jp/oembed.{format}",
+    "urls": [
         "^http(?:s)?://(?:www\\.)?roomshare\\.jp/(?:en/)?post/.+$"
     ],
-    "http://crowdranking.com/api/oembed.{format}": [
+}
+
+crowd_ranking = {
+    "endpoint": "http://crowdranking.com/api/oembed.{format}",
+    "urls": [
         "^http(?:s)?://crowdranking\\.com/crowdrankings/.+$",
         "^http(?:s)?://crowdranking\\.com/rankings/.+$",
         "^http(?:s)?://crowdranking\\.com/topics/.+$",
         "^http(?:s)?://crowdranking\\.com/widgets/.+$",
         "^http(?:s)?://crowdranking\\.com/r/.+$"
     ],
-    "http://openapi.etsy.com/svc/oembed/": [
+}
+
+etsy = {
+    "endpoint": "http://openapi.etsy.com/svc/oembed/",
+    "urls": [
         "^http(?:s)?://(?:www\\.)?etsy\\.com/listing/.+$"
     ],
-    "https://audioboo.fm/publishing/oembed.{format}": [
+}
+
+audioboo = {
+    "endpoint": "https://audioboo.fm/publishing/oembed.{format}",
+    "urls": [
         "^http(?:s)?://audioboo\\.fm/boos/.+$"
     ],
-    "http://demo.clikthrough.com/services/oembed/": [
+}
+
+clikthrough = {
+    "endpoint": "http://demo.clikthrough.com/services/oembed/",
+    "urls": [
         "^http(?:s)?://demo\\.clikthrough\\.com/theater/video/.+$"
     ],
-    "http://www.ifttt.com/oembed/": [
+}
+
+ifttt = {
+    "endpoint": "http://www.ifttt.com/oembed/",
+    "urls": [
         "^http(?:s)?://ifttt\\.com/recipes/.+$"
     ],
+}
 
-    # Added 11th December 2014 - http://developers.issuu.com/api/oembed.html
-    "http://issuu.com/oembed": [
+issuu = {
+    "endpoint": "http://issuu.com/oembed",
+    "urls": [
         "^http(?:s)?://(?:www\\.)?issuu\\.com/[^#?/]+/docs/.+$"
     ],
 }
 
 
-# Compile endpoints into regular expression objects
-import re
-
-
-def compile_endpoints():
-    endpoints = {}
-    for endpoint in OEMBED_ENDPOINTS.keys():
-        endpoint_key = endpoint.replace('{format}', 'json')
-
-        endpoints[endpoint_key] = []
-        for pattern in OEMBED_ENDPOINTS[endpoint]:
-            endpoints[endpoint_key].append(re.compile(pattern))
-
-    return endpoints
-
-OEMBED_ENDPOINTS_COMPILED = compile_endpoints()
-
-
-def get_oembed_provider(url):
-    for endpoint in OEMBED_ENDPOINTS_COMPILED.keys():
-        for pattern in OEMBED_ENDPOINTS_COMPILED[endpoint]:
-            if re.match(pattern, url):
-                return endpoint
-
-    return
+all_providers = [
+    speakerdeck, app_net, youtube, deviantart, blip_tv, dailymotion, flikr,
+    hulu, nfb, qik, revision3, scribd, viddler, vimeo, dotsub, yfrog,
+    clickthrough, kinomap, photobucket, instagram, slideshare,
+    major_league_gaming, opera, skitch, twitter, soundcloud, collegehumor,
+    polleverywhere, ifixit, smugmug, github_gist, animoto, rdio, five_min,
+    five_hundred_px, dipdive, yandex, mixcloud, kickstarter, coub, screenr,
+    funny_or_die, wistia, ustream, wordpress, polldaddy, bambuser, ted, chirb,
+    circuitlab, geograph_uk, hlipp, geograph_gg, vzaar, minoto, videojug, sapo,
+    vhx_tv, justin_tv, official_fm, huffduffer, spotify, shoudio, mobypicture,
+    twenty_three_hq, gmep, urtak, cacoo, dailymile, dipity, sketchfab, meetup,
+    roomshare, crowd_ranking, etsy, audioboo, clikthrough, ifttt, issuu
+]

--- a/wagtail/wagtailembeds/rich_text.py
+++ b/wagtail/wagtailembeds/rich_text.py
@@ -1,4 +1,5 @@
-from wagtail.wagtailembeds import format, embeds
+from wagtail.wagtailembeds import format
+from wagtail.wagtailembeds.exceptions import EmbedException
 
 
 class MediaEmbedHandler(object):
@@ -28,7 +29,7 @@ class MediaEmbedHandler(object):
         if for_editor:
             try:
                 return format.embed_to_editor_html(attrs['url'])
-            except embeds.EmbedException:
+            except EmbedException:
                 # Could be replaced with a nice error message
                 return ''
         else:

--- a/wagtail/wagtailembeds/templatetags/wagtailembeds_tags.py
+++ b/wagtail/wagtailembeds/templatetags/wagtailembeds_tags.py
@@ -2,7 +2,7 @@ from django import template
 from django.utils.safestring import mark_safe
 
 from wagtail.wagtailembeds import embeds
-
+from wagtail.wagtailembeds.exceptions import EmbedException
 
 register = template.Library()
 
@@ -12,5 +12,5 @@ def embed(url, max_width=None):
     try:
         embed = embeds.get_embed(url, max_width=max_width)
         return mark_safe(embed.html)
-    except embeds.EmbedException:
+    except EmbedException:
         return ''

--- a/wagtail/wagtailembeds/tests.py
+++ b/wagtail/wagtailembeds/tests.py
@@ -10,7 +10,7 @@ except ImportError:
 
 import django.utils.six.moves.urllib.request
 from django import template
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse
 from django.utils.six.moves.urllib.error import URLError
@@ -27,9 +27,40 @@ from wagtail.wagtailembeds.finders.embedly import (
     embedly as wagtail_embedly,
 )
 from wagtail.wagtailembeds.finders.oembed import oembed as wagtail_oembed
+from wagtail.wagtailembeds.finders import get_default_finder
 from wagtail.wagtailembeds.templatetags.wagtailembeds_tags import embed as embed_filter
 from wagtail.wagtailembeds.blocks import EmbedBlock, EmbedValue
 from wagtail.wagtailembeds.models import Embed
+
+
+class TestGetDefaultFinder(TestCase):
+    def test_defaults_to_oembed(self):
+        self.assertEqual(get_default_finder(), wagtail_oembed)
+
+    @override_settings(WAGTAILEMBEDS_EMBEDLY_KEY='test')
+    def test_defaults_to_embedly_when_embedly_key_set(self):
+        self.assertEqual(get_default_finder(), wagtail_embedly)
+
+    @override_settings(WAGTAILEMBEDS_EMBED_FINDER='wagtail.wagtailembeds.finders.embedly.embedly')
+    def test_find_embedly(self):
+        self.assertEqual(get_default_finder(), wagtail_embedly)
+
+    @override_settings(WAGTAILEMBEDS_EMBED_FINDER='wagtail.wagtailembeds.finders.oembed.oembed')
+    def test_find_oembed(self):
+        self.assertEqual(get_default_finder(), wagtail_oembed)
+
+    @override_settings(WAGTAILEMBEDS_EMBED_FINDER='wagtail.wagtailembeds.embeds.embedly')
+    def test_find_old_embedly(self):
+        self.assertEqual(get_default_finder(), wagtail_embedly)
+
+    @override_settings(WAGTAILEMBEDS_EMBED_FINDER='wagtail.wagtailembeds.embeds.oembed')
+    def test_find_old_oembed(self):
+        self.assertEqual(get_default_finder(), wagtail_oembed)
+
+    @override_settings(WAGTAILEMBEDS_EMBEDLY_KEY='test', WAGTAILEMBEDS_EMBED_FINDER='wagtail.wagtailembeds.finders.oembed.oembed')
+    def test_find_oembed_when_embedly_key_set(self):
+        # WAGTAILEMBEDS_EMBED_FINDER always takes precedence
+        self.assertEqual(get_default_finder(), wagtail_oembed)
 
 
 class TestEmbeds(TestCase):

--- a/wagtail/wagtailembeds/tests.py
+++ b/wagtail/wagtailembeds/tests.py
@@ -19,14 +19,14 @@ from wagtail.wagtailcore import blocks
 from wagtail.tests.utils import WagtailTestUtils
 
 from wagtail.wagtailembeds.rich_text import MediaEmbedHandler
-from wagtail.wagtailembeds.embeds import (
-    EmbedNotFoundException,
+from wagtail.wagtailembeds.embeds import get_embed
+from wagtail.wagtailembeds.exceptions import EmbedNotFoundException
+from wagtail.wagtailembeds.finders.embedly import (
     EmbedlyException,
     AccessDeniedEmbedlyException,
-    get_embed,
     embedly as wagtail_embedly,
-    oembed as wagtail_oembed,
 )
+from wagtail.wagtailembeds.finders.oembed import oembed as wagtail_oembed
 from wagtail.wagtailembeds.templatetags.wagtailembeds_tags import embed as embed_filter
 from wagtail.wagtailembeds.blocks import EmbedBlock, EmbedValue
 from wagtail.wagtailembeds.models import Embed

--- a/wagtail/wagtailembeds/tests.py
+++ b/wagtail/wagtailembeds/tests.py
@@ -49,6 +49,14 @@ class TestGetDefaultFinder(TestCase):
     def test_find_oembed(self):
         self.assertEqual(get_default_finder(), wagtail_oembed)
 
+    @override_settings(WAGTAILEMBEDS_EMBED_FINDER='wagtail.wagtailembeds.finders.embedly')
+    def test_find_embedly_from_module(self):
+        self.assertEqual(get_default_finder(), wagtail_embedly)
+
+    @override_settings(WAGTAILEMBEDS_EMBED_FINDER='wagtail.wagtailembeds.finders.oembed')
+    def test_find_oembed_from_module(self):
+        self.assertEqual(get_default_finder(), wagtail_oembed)
+
     @override_settings(WAGTAILEMBEDS_EMBED_FINDER='wagtail.wagtailembeds.embeds.embedly')
     def test_find_old_embedly(self):
         self.assertEqual(get_default_finder(), wagtail_embedly)

--- a/wagtail/wagtailembeds/tests.py
+++ b/wagtail/wagtailembeds/tests.py
@@ -31,6 +31,7 @@ from wagtail.wagtailembeds.finders import get_finders
 from wagtail.wagtailembeds.templatetags.wagtailembeds_tags import embed as embed_filter
 from wagtail.wagtailembeds.blocks import EmbedBlock, EmbedValue
 from wagtail.wagtailembeds.models import Embed
+from wagtail.wagtailembeds import oembed_providers
 
 
 class TestGetFinders(TestCase):
@@ -423,6 +424,14 @@ class TestOembed(TestCase):
             'height': 'test_height',
             'html': 'test_html'
         })
+
+    def test_oembed_accepts_known_provider(self):
+        finder = OEmbedFinder(providers=[oembed_providers.youtube])
+        self.assertTrue(finder.accept("http://www.youtube.com/watch/"))
+
+    def test_oembed_doesnt_accept_unknown_provider(self):
+        finder = OEmbedFinder(providers=[oembed_providers.twitter])
+        self.assertFalse(finder.accept("http://www.youtube.com/watch/"))
 
 
 class TestEmbedFilter(TestCase):

--- a/wagtail/wagtailembeds/tests.py
+++ b/wagtail/wagtailembeds/tests.py
@@ -68,6 +68,19 @@ class TestGetFinders(TestCase):
 
     @override_settings(WAGTAILEMBEDS_EMBED_FINDERS=[
         {
+            'class': 'wagtail.wagtailembeds.finders.oembed',
+            'options': {'foo': 'bar'}
+        }
+    ])
+    def test_new_find_oembed_with_options(self):
+        finders = get_finders()
+
+        self.assertEqual(len(finders), 1)
+        self.assertIsInstance(finders[0], OEmbedFinder)
+        self.assertEqual(finders[0].options, {'foo': 'bar'})
+
+    @override_settings(WAGTAILEMBEDS_EMBED_FINDERS=[
+        {
             'class': 'wagtail.wagtailembeds.finders.embedly',
         }
     ], WAGTAILEMBEDS_EMBEDLY_KEY='bar')

--- a/wagtail/wagtailembeds/views/chooser.py
+++ b/wagtail/wagtailembeds/views/chooser.py
@@ -5,7 +5,8 @@ from wagtail.wagtailadmin.modal_workflow import render_modal_workflow
 from wagtail.wagtailembeds.forms import EmbedForm
 from wagtail.wagtailembeds.format import embed_to_editor_html
 
-from wagtail.wagtailembeds.embeds import EmbedNotFoundException, EmbedlyException, AccessDeniedEmbedlyException
+from wagtail.wagtailembeds.exceptions import EmbedNotFoundException
+from wagtail.wagtailembeds.finders.embedly import EmbedlyException, AccessDeniedEmbedlyException
 
 
 def chooser(request):


### PR DESCRIPTION
This pull request implements class based embed finders and a new embed finder configuration. I hope this will make embed finders more configurable solving the following problems:

 - Allow additional oembed providers to be used (currently all are hardcoded)
 - Make per-provider configuration possible
  - Choose which finders get used for which provider (eg, force use of oembed for instagram but use embedly for everything else)
  - Allow specifying additional parameters for certian providers such as ``scheme=https`` to YouTube

For example, the below configuration would use oembed for fetching youtube videos and embedly for everything else. All youtube videos would be fetched with ``scheme=https``.

```python
from wagtail.wagtailembeds.oembed_providers import youtube, all_providers

ISSUU = {
    'endpoint': 'http://issuu.com/oembed',
    'urls': [
        '^http(?:s)?://(?:www\\.)?issuu\\.com/[^#?/]+/docs/.+$',
    ]
}

WAGTAILEMBEDS_FINDERS = [
    {  # Override Youtube oEmbed provider to pass through an extra option
        'finder': 'wagtail.wagtailembeds.finders.oembed',
        'providers': [youtube],
        'options': {'scheme': 'https'}
    },
    {  # Then try all other builtin oEmbed providers, and a custom one
        'finder': 'wagtail.wagtailembeds.finders.oembed',
        'providers': all_providers + [ISSUU]
    },
    {  # Fallback to Embedly
        'finder': 'wagtail.wagtailembeds.finders.embedly',
        'key': 'mykey'
    },
]
```