### PR TITLE
author specific locking tweaks

### DIFF
--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -224,6 +224,22 @@ Hooks for building new areas of the admin interface (alongside pages, images, do
   As ``construct_main_menu``, but modifies the 'Settings' sub-menu rather than the top-level menu.
 
 
+.. _register_reports_menu_item:
+
+``register_reports_menu_item``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  As ``register_admin_menu_item``, but registers menu items into the 'Reports' sub-menu rather than the top-level menu.
+
+
+.. _construct_reports_menu:
+
+``construct_reports_menu``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  As ``construct_main_menu``, but modifies the 'Reports' sub-menu rather than the top-level menu.
+
+
 .. _register_admin_search_area:
 
 ``register_admin_search_area``

--- a/docs/reference/pages/model_reference.rst
+++ b/docs/reference/pages/model_reference.rst
@@ -115,7 +115,7 @@ Database fields
 
         The user who has currently locked the page. Only this user can edit the page.
 
-        If this is ``None`` when ``locked`` is ``False``, nobody can edit the page.
+        If this is ``None`` when ``locked`` is ``True``, nobody can edit the page.
 
     .. attribute:: locked_at
 

--- a/wagtail/admin/templates/wagtailadmin/home/locked_pages.html
+++ b/wagtail/admin/templates/wagtailadmin/home/locked_pages.html
@@ -3,7 +3,9 @@
     <div class="panel nice-padding">{# TODO try moving these classes onto the section tag #}
         <section>
             <h2>{% trans "Your locked pages" %}</h2>
-            <a href="{% url 'wagtailadmin_reports:locked_pages' %}" class="button button-small button-secondary">{% trans "See all locked pages" %}</a>
+            {% if can_remove_locks %}
+                <a href="{% url 'wagtailadmin_reports:locked_pages' %}" class="button button-small button-secondary">{% trans "See all locked pages" %}</a>
+            {% endif %}
             <table class="listing listing-page">
                 <col />
                 <col width="15%"/>

--- a/wagtail/admin/templates/wagtailadmin/reports/listing/_list_unlock.html
+++ b/wagtail/admin/templates/wagtailadmin/reports/listing/_list_unlock.html
@@ -7,23 +7,27 @@
     <td>
         {% page_permissions page as perms %}
         <p>
-            {% with page.locked_at|date:"d M Y H:i" as locking_date %}
-                {% if page.locked_by %}
-                    {% if page.locked_by_id == request.user.pk %}
-                        {% blocktrans %}
-                            Locked by <b>you</b> at <b>{{ locking_date }}</b>
-                        {% endblocktrans %}
+            {% if page.locked_at %}
+                {% with page.locked_at|date:"d M Y H:i" as locking_date %}
+                    {% if page.locked_by %}
+                        {% if page.locked_by_id == request.user.pk %}
+                            {% blocktrans %}
+                                Locked by <b>you</b> at <b>{{ locking_date }}</b>
+                            {% endblocktrans %}
+                        {% else %}
+                            {% blocktrans with locked_by=page.locked_by %}
+                                Locked by <b>{{ locked_by }}</b> at <b>{{ locking_date }}</b>
+                            {% endblocktrans %}
+                        {% endif %}
                     {% else %}
-                        {% blocktrans with locked_by=page.locked_by %}
-                            Locked by <b>{{ locked_by }}</b> at <b>{{ locking_date }}</b>
+                        {% blocktrans %}
+                            Locked at <b>{{ locking_date }}</b>
                         {% endblocktrans %}
                     {% endif %}
-                {% else %}
-                    {% blocktrans %}
-                        Locked at <b>{{ locking_date }}</b>
-                    {% endblocktrans %}
-                {% endif %}
-            {% endwith %}
+                {% endwith %}
+            {% else %}
+                {% trans 'Locked' %}
+            {% endif %}
         </p>
         {% if perms.can_unlock %}
             <form action="{% url 'wagtailadmin_pages:unlock' page.id %}" method="post">

--- a/wagtail/admin/templates/wagtailadmin/reports/listing/_list_unlock.html
+++ b/wagtail/admin/templates/wagtailadmin/reports/listing/_list_unlock.html
@@ -2,13 +2,28 @@
 
 {% load i18n wagtailadmin_tags %}
 
+
 {% block page_navigation %}
     <td>
         {% page_permissions page as perms %}
         <p>
-            Locked
-            {% if page.locked_by %}by <b>{% if page.locked_by_id == request.user.pk %}you{% else %}{{ page.locked_by }}{% endif %}</b>{% endif %}
-            {% if page.locked_at %}at <b>{{ page.locked_at|date:"d M Y H:i" }}</b>{% endif %}
+            {% with page.locked_at|date:"d M Y H:i" as locking_date %}
+                {% if page.locked_by %}
+                    {% if page.locked_by_id == request.user.pk %}
+                        {% blocktrans %}
+                            Locked by <b>you</b> at <b>{{ locking_date }}</b>
+                        {% endblocktrans %}
+                    {% else %}
+                        {% blocktrans with locked_by=page.locked_by %}
+                            Locked by <b>{{ locked_by }}</b> at <b>{{ locking_date }}</b>
+                        {% endblocktrans %}
+                    {% endif %}
+                {% else %}
+                    {% blocktrans %}
+                        Locked at <b>{{ locking_date }}</b>
+                    {% endblocktrans %}
+                {% endif %}
+            {% endwith %}
         </p>
         {% if perms.can_unlock %}
             <form action="{% url 'wagtailadmin_pages:unlock' page.id %}" method="post">

--- a/wagtail/admin/tests/test_reports_views.py
+++ b/wagtail/admin/tests/test_reports_views.py
@@ -1,0 +1,35 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from wagtail.core.models import Page
+from wagtail.tests.utils import WagtailTestUtils
+
+
+class TestLockedPagesView(TestCase, WagtailTestUtils):
+    def setUp(self):
+        self.user = self.login()
+
+    def get(self, params={}):
+        return self.client.get(reverse('wagtailadmin_reports:locked_pages'), params)
+
+    def test_simple(self):
+        response = self.get()
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'wagtailadmin/reports/locked_pages.html')
+
+        # Initially there should be no locked pages
+        self.assertContains(response, "No locked pages found.")
+
+        self.page = Page.objects.first()
+        self.page.locked = True
+        self.page.locked_by = self.user
+        self.page.locked_at = timezone.now()
+        self.page.save()
+
+        # Now the listing should contain our locked page
+        response = self.get()
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'wagtailadmin/reports/locked_pages.html')
+        self.assertNotContains(response, "No locked pages found.")
+        self.assertContains(response, self.page.title)

--- a/wagtail/admin/views/home.py
+++ b/wagtail/admin/views/home.py
@@ -59,7 +59,8 @@ class LockedPagesPanel:
             'locked_pages': Page.objects.filter(
                 locked=True,
                 locked_by=self.request.user,
-            )
+            ),
+            'can_remove_locks': UserPagePermissionsProxy(self.request.user).can_remove_locks()
         }, request=self.request)
 
 

--- a/wagtail/admin/views/reports.py
+++ b/wagtail/admin/views/reports.py
@@ -31,6 +31,6 @@ class LockedPagesView(ReportView):
         return super().get_queryset()
 
     def dispatch(self, request, *args, **kwargs):
-        if not UserPagePermissionsProxy(request.user).can_unlock_pages():
+        if not UserPagePermissionsProxy(request.user).can_remove_locks():
             return permission_denied(request)
         return super().dispatch(request, *args, **kwargs)

--- a/wagtail/admin/views/reports.py
+++ b/wagtail/admin/views/reports.py
@@ -2,6 +2,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.views.generic.base import TemplateResponseMixin
 from django.views.generic.list import BaseListView
 
+from wagtail.admin.auth import permission_denied
 from wagtail.core.models import UserPagePermissionsProxy
 
 
@@ -28,3 +29,8 @@ class LockedPagesView(ReportView):
         pages = UserPagePermissionsProxy(self.request.user).editable_pages().filter(locked=True)
         self.queryset = pages
         return super().get_queryset()
+
+    def dispatch(self, request, *args, **kwargs):
+        if not UserPagePermissionsProxy(request.user).can_unlock_pages():
+            return permission_denied(request)
+        return super().dispatch(request, *args, **kwargs)

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -622,7 +622,7 @@ class ReportsMenuItem(SubmenuMenuItem):
 
 class LockedPagesMenuItem(MenuItem):
     def is_shown(self, request):
-        return UserPagePermissionsProxy(request.user).can_unlock_pages()
+        return UserPagePermissionsProxy(request.user).can_remove_locks()
 
 
 @hooks.register('register_reports_menu_item')

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -620,9 +620,14 @@ class ReportsMenuItem(SubmenuMenuItem):
     template = 'wagtailadmin/shared/menu_submenu_item.html'
 
 
+class LockedPagesMenuItem(MenuItem):
+    def is_shown(self, request):
+        return UserPagePermissionsProxy(request.user).can_unlock_pages()
+
+
 @hooks.register('register_reports_menu_item')
 def register_locked_pages_menu_item():
-    return MenuItem(_('Locked Pages'), reverse('wagtailadmin_reports:locked_pages'), classnames='icon icon-locked', order=700)
+    return LockedPagesMenuItem(_('Locked Pages'), reverse('wagtailadmin_reports:locked_pages'), classnames='icon icon-locked', order=700)
 
 
 @hooks.register('register_admin_menu_item')

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -1835,7 +1835,12 @@ class UserPagePermissionsProxy:
 
     def can_remove_locks(self):
         """Returns True if the user has permission to unlock pages they have not locked"""
-        return self.user.is_superuser or self.permissions.filter(permission_type='unlock').exists()
+        if self.user.is_superuser:
+            return True
+        if not self.user.is_active:
+            return False
+        else:
+            return self.permissions.filter(permission_type='unlock').exists()
 
 
 class PagePermissionTester:

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -1833,6 +1833,30 @@ class UserPagePermissionsProxy:
         """Return True if the user has permission to publish any pages"""
         return self.publishable_pages().exists()
 
+    def unlockable_pages(self):
+        """Return a queryset of the pages that this user has permission to unlock"""
+        # Deal with the trivial cases first...
+        if not self.user.is_active:
+            return Page.objects.none()
+        if self.user.is_superuser:
+            return Page.objects.all()
+
+        unlockable_pages = Page.objects.none()
+
+        for perm in self.permissions.filter(permission_type='unlock'):
+            # user has publish permission on any subpage of perm.page
+            # (including perm.page itself)
+            unlockable_pages |= Page.objects.descendant_of(perm.page, inclusive=True)
+
+        pages_locked_by_user = Page.objects.filter(locked_by=self.user)
+        unlockable_pages |= pages_locked_by_user
+
+        return unlockable_pages
+
+    def can_unlock_pages(self):
+        """Return True if the user has permission to unlock any pages"""
+        return self.unlockable_pages().exists()
+
 
 class PagePermissionTester:
     def __init__(self, user_perms, page):

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -1833,29 +1833,9 @@ class UserPagePermissionsProxy:
         """Return True if the user has permission to publish any pages"""
         return self.publishable_pages().exists()
 
-    def unlockable_pages(self):
-        """Return a queryset of the pages that this user has permission to unlock"""
-        # Deal with the trivial cases first...
-        if not self.user.is_active:
-            return Page.objects.none()
-        if self.user.is_superuser:
-            return Page.objects.all()
-
-        unlockable_pages = Page.objects.none()
-
-        for perm in self.permissions.filter(permission_type='unlock'):
-            # user has publish permission on any subpage of perm.page
-            # (including perm.page itself)
-            unlockable_pages |= Page.objects.descendant_of(perm.page, inclusive=True)
-
-        pages_locked_by_user = Page.objects.filter(locked_by=self.user)
-        unlockable_pages |= pages_locked_by_user
-
-        return unlockable_pages
-
-    def can_unlock_pages(self):
-        """Return True if the user has permission to unlock any pages"""
-        return self.unlockable_pages().exists()
+    def can_remove_locks(self):
+        """Returns True if the user has permission to unlock pages they have not locked"""
+        return self.user.is_superuser or self.permissions.filter(permission_type='unlock').exists()
 
 
 class PagePermissionTester:


### PR DESCRIPTION
Addresses feedback from @gasman: https://github.com/wagtail/wagtail/pull/5634

- Makes locked message in locked pages report compatible with translation
- Corrects a mistake (False instead of True) in documentation
- Adds `can_unlock_pages` and `unlockable_pages` methods to `UserPagePermissionsProxy`, and uses them to only show the Locked Pages report menu item and view when the user can unlock pages
