### PR TITLE
Close page chooser modal with escape key input

### DIFF
--- a/client/src/components/choosers/page/PageChooser.js
+++ b/client/src/components/choosers/page/PageChooser.js
@@ -24,12 +24,20 @@ const defaultProps = {
 
 class PageChooser extends ModalWindow {
   componentDidMount() {
-    const { browse, initialParentPageId } = this.props;
+    const { browse, initialParentPageId, onModalClose } = this.props;
 
     browse(initialParentPageId || 'root', 1);
 
     // Focus the search box
     document.getElementById(`${this.state.id}-search`).focus();
+
+    document.addEventListener('keydown', onModalClose);
+  }
+
+  componentWillUnmount() {
+    const { onModalClose } = this.props;
+
+    document.removeEventListener('keydown', onModalClose);
   }
 
   renderModalContents() {


### PR DESCRIPTION
@kaedroho I think ModalWindow would've been a better place to add these event listeners but after some research, it looks like inheriting states isn't very 'react'. What are your thoughts?